### PR TITLE
[move] Audit Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,6 @@ Has 4 modules; core, master, profile & receipt.
     - `npm run testMasterUnsuspend` to update a master's sale_status field to RETAINED.
       - Admin action.
       - Requires a master to be minted first under a profile and be suspended.
+    - `npm run testMetadataSetTitleAndSync` to set a title for a Metadata object and sync it with the master.
+      - Requires a master to be minted first under a profile.
   - To check transaction outputs in detail you can visit an explorer such as [Sui Explorer](https://suiexplorer.com/?network=testnet) and paste the digest in the search bar, which is printed by each script command, to see the full transaction effects.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ Has 4 modules; core, master, profile & receipt.
     - `npm run testMasterBuy` to buy a master provided that the user has paid for it and received a receipt beforehand.
       - Requires a profile, a master on sale & a receipt.
     - `npm run testMasterSetOnSale` to update a master's sale_status field to ON_SALE.
+      - User action.
       - Requires a master to be minted first under a profile.
     - `npm run testMasterRetain` to update a master's sale_status field to RETAINED.
+      - User action. This is the unlist action.
       - Requires a master to be minted first under a profile.
     - `npm run testMasterSuspend` to update a master's sale_status field to SUSPENDED.
+      - Admin action.
       - Requires a master to be minted first under a profile.
+    - `npm run testMasterUnsuspend` to update a master's sale_status field to RETAINED.
+      - Admin action.
+      - Requires a master to be minted first under a profile and be suspended.
   - To check transaction outputs in detail you can visit an explorer such as [Sui Explorer](https://suiexplorer.com/?network=testnet) and paste the digest in the search bar, which is printed by each script command, to see the full transaction effects.

--- a/move/sources/core.move
+++ b/move/sources/core.move
@@ -75,6 +75,7 @@ module recrd::core {
 
   /// Admin can update the registry's version.
   public fun bump_registry_version(registry: &mut Registry, _: &AdminCap) {
+    assert!(VERSION > registry.version, EWrongVersion);
     registry.version = VERSION;
   }
 

--- a/move/sources/identity.move
+++ b/move/sources/identity.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+module recrd::identity {
+  use recrd::core::AdminCap;
+
+  // === Custom Receivers ===
+  use fun new as ID.new;
+
+  // Profile identity for users to link their account to their Profile. 
+  public struct Identity has key {
+    id: UID,
+    profile: ID,
+  }
+
+  // === Admin Functions ===
+
+  /// Admin can send more Identities to users that have existing Profile. 
+  public fun admin_new(_: &AdminCap, profile_id: ID, ctx: &mut TxContext): Identity {
+    profile_id.new(ctx)
+  }
+
+  public fun admin_transfer(_: &AdminCap, self: Identity, addr: address) {
+    self.transfer(addr);
+  }
+
+  // === Public Functions ===
+  public fun burn(self: Identity) {
+    let Identity { id, profile: _ } = self;
+    id.delete();
+  }
+
+  // === Private Functions ===
+
+  // Internal transfer function for `Identity`.
+  public(package) fun transfer(self: Identity, addr: address) {
+    transfer::transfer(self, addr);
+  }
+
+  /// Creates and returns a new Identity object. 
+  public(package) fun new(profile_id: ID, ctx: &mut TxContext): Identity {
+    Identity {
+      id: object::new(ctx),
+      profile: profile_id,
+    }
+  }
+
+  #[test_only]
+  public fun create_for_testing(profile_id: ID, ctx: &mut TxContext): Identity {
+    new(profile_id, ctx)
+  }
+}

--- a/move/sources/identity.move
+++ b/move/sources/identity.move
@@ -23,12 +23,6 @@ module recrd::identity {
     self.transfer(addr);
   }
 
-  // === Public Functions ===
-  public fun burn(self: Identity) {
-    let Identity { id, profile: _ } = self;
-    id.delete();
-  }
-
   // === Private Functions ===
 
   // Internal transfer function for `Identity`.

--- a/move/sources/identity.move
+++ b/move/sources/identity.move
@@ -19,6 +19,7 @@ module recrd::identity {
     profile_id.new(ctx)
   }
 
+  /// Admin can transfer Identities to other users.
   public fun admin_transfer(_: &AdminCap, self: Identity, addr: address) {
     self.transfer(addr);
   }

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -12,7 +12,6 @@ module recrd::master {
   use sui::package;
   use sui::display;
   use recrd::core::AdminCap;
-  use recrd::identity::Identity;
 
   // === Errors ===
   const EHashtagDoesNotExist: u64 = 1;
@@ -407,8 +406,7 @@ module recrd::master {
 
   // Lists Master for sale by setting status to ON_SALE. 
   // This allows a Receipt to be issued for a Master.
-  // Only users that hold a `Identity` cap object can call this.
-  public fun list<T>( _: &Identity, master: &mut Master<T>) {
+  public fun list<T>(master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot be set for sale. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeListed);
 
@@ -420,8 +418,7 @@ module recrd::master {
   }
 
   // Unlists Master from market by reverting status to RETAINED.
-  // Only users that hold a `Identity` cap object can call this.
-  public fun unlist<T>( _: &Identity, master: &mut Master<T>) {
+  public fun unlist<T>(master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot revert status to retained. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeRetained);
 

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -52,9 +52,7 @@ module recrd::master {
     // Media file URL for master video or audio
     media_url: String,
     // sale status of master
-    sale_status: u8,
-    // whether master resides in RECRD ecosystem
-    exported: bool,
+    sale_status: u8
   }
 
   // Master metadata object that will hold all master-related metadata.
@@ -86,13 +84,13 @@ module recrd::master {
     // revenue total (synced by RECRD)
     revenue_total: u64,
     // revenue available to be paid to creator (synced by RECRD)
-    // TODO: clarify if this amount is to be paid to `creator_profile_id`
     revenue_available: u64, 
     // keep track of revenue paid out
-    // TODO: clarify if this amount refers to `creator_profile_id`
     revenue_paid: u64,
     // (optional) show how much revenue is pending for withdrawal
     revenue_pending: u64,
+    // whether master resides in RECRD ecosystem
+    master_exported: bool,
   }
 
   // One-time-function that runs when the contract is deployed.
@@ -227,6 +225,7 @@ module recrd::master {
       revenue_available,
       revenue_paid,
       revenue_pending,
+      master_exported: false
     };
 
     // Publicly share the metadata object. 
@@ -239,8 +238,7 @@ module recrd::master {
       title,
       image_url,
       media_url,
-      sale_status,
-      exported: false,
+      sale_status
     }
   }
 
@@ -254,8 +252,7 @@ module recrd::master {
       title: _,
       image_url: _,
       media_url: _,
-      sale_status: _,
-      exported: _,
+      sale_status: _
     } = master;
 
     // Delete the `Master<T>` object and its UID.
@@ -284,6 +281,7 @@ module recrd::master {
       revenue_available: _,
       revenue_paid: _,
       revenue_pending: _,
+      master_exported: _
     } = metadata;
 
     // Delete the `Metadata<T>` object and its UID.
@@ -292,14 +290,14 @@ module recrd::master {
   
   /// Admin can update the `exported` field in case the `Master` is moved from
   /// a `Profile` to a user address.
-  public fun export<T>(_: &AdminCap, master: &mut Master<T>) {
-    master.exported = true;
+  public fun export<T>(_: &AdminCap, metadata: &mut Metadata<T>) {
+    metadata.master_exported = true;
   }
 
   /// Update the `exported` field when a `Master` is being brought back into 
   /// the RECRD ecosystem under a `Profile`.
-  public fun import<T>(_: &AdminCap, master: &mut Master<T>) {
-    master.exported = false;
+  public fun import<T>(_: &AdminCap, metadata: &mut Metadata<T>) {
+    metadata.master_exported = false;
   }
 
   // === Master Accessors ===
@@ -476,7 +474,7 @@ module recrd::master {
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     // Only allow update when Master is in RECRD ecosystem.
-    assert!(master.exported == false, EUpdateNotAllowed);
+    assert!(metadata.master_exported == false, EUpdateNotAllowed);
     metadata.title = title;
   }
 
@@ -487,7 +485,7 @@ module recrd::master {
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     // Only allow update when Master is in RECRD ecosystem.
-    assert!(master.exported == false, EUpdateNotAllowed);
+    assert!(metadata.master_exported == false, EUpdateNotAllowed);
     metadata.description = description;
   }
 
@@ -498,7 +496,7 @@ module recrd::master {
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     // Only allow update when Master is in RECRD ecosystem.
-    assert!(master.exported == false, EUpdateNotAllowed);
+    assert!(metadata.master_exported == false, EUpdateNotAllowed);
     metadata.image_url = image_url;
   }
   

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -404,11 +404,13 @@ module recrd::master {
   }
 
   // Lists Master for sale by setting status to ON_SALE. 
+  // This allows a Receipt to be issued for a Master.
   public fun list<T>(master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot be set for sale. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeListed);
 
     // Don't allow status update if a Receipt has been issued for master.
+    // Once a Receipt is minted, the sale_status is set to CLAIMED.
     assert!(master.sale_status != CLAIMED, EItemHasBeenClaimed);
 
     master.sale_status = ON_SALE;

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -100,10 +100,12 @@ module recrd::master {
 
     // Create the display for `Master<T>`
     let master_keys = vector[
-      utf8(b"Name"),
-      utf8(b"Image URL"),
-      utf8(b"Media URL"),
-      utf8(b"Metadata Ref"),
+      utf8(b"name"),
+      utf8(b"image_url"),
+      utf8(b"medial_url"),
+      utf8(b"metadata_ref"),
+      utf8(b"project_url"),
+      utf8(b"creator"),
     ];
 
     let master_values = vector[
@@ -111,6 +113,8 @@ module recrd::master {
       utf8(b"{image_url}"),
       utf8(b"{media_url}"),
       utf8(b"{metadata_ref}"),
+      utf8(b"https://www.recrd.com/"),
+      utf8(b"RECRD"),
     ];
 
     // Create and populate display for `Master<Video>`
@@ -129,15 +133,17 @@ module recrd::master {
 
     // Create the display for `Metadata<T>`
     let metadata_keys = vector[
-      utf8(b"Title"),
-      utf8(b"Description"),
-      utf8(b"Image URL"),
-      utf8(b"Media URL"),
-      utf8(b"Hashtags"),
-      utf8(b"Creator"),
-      utf8(b"Parent"),
-      utf8(b"Origin"),
-      utf8(b"Expressions"),
+      utf8(b"name"),
+      utf8(b"description"),
+      utf8(b"image_url"),
+      utf8(b"media_url"),
+      utf8(b"hashtags"),
+      utf8(b"creator_profile"),
+      utf8(b"parent"),
+      utf8(b"origin"),
+      utf8(b"expressions"),
+      utf8(b"project_url"),
+      utf8(b"creator"),
     ];
 
     let metadata_values = vector[
@@ -150,6 +156,8 @@ module recrd::master {
       utf8(b"{master_metadata_parent}"),
       utf8(b"{master_metadata_origin}"),
       utf8(b"{expressions}"),
+      utf8(b"https://www.recrd.com/"),
+      utf8(b"RECRD"),
     ];
 
     // Create and populate display for `Metadata<Video>`

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -286,10 +286,6 @@ module recrd::master {
   
   // === Master Accessors ===
 
-  public fun id<T>(master: &Master<T>): ID {
-    master.id.to_inner()
-  }
-
   public fun metadata_ref<T>(master: &Master<T>): &ID {
     &master.metadata_ref
   }

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -19,6 +19,7 @@ module recrd::master {
   const EInvalidNewRevenuePaid: u64 = 3;
   const ESuspendedItemCannotBeListed: u64 = 4;
   const ESuspendedItemCannotBeRetained: u64 = 5;
+  const EInvalidMetadataForMaster: u64 = 6;
 
   // === Constants ===
   const RETAINED: u8 = 1;
@@ -384,16 +385,19 @@ module recrd::master {
 
   // Sync Master title with the title in Metadata.
   public fun sync_title<T>(master: &mut Master<T>, metadata: &Metadata<T>) {
+    assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     master.title = metadata.title;
   }
 
   // Sync Master image URL with the image URL in Metadata.
   public fun sync_image_url<T>(master: &mut Master<T>, metadata: &Metadata<T>) {
+    assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     master.image_url = metadata.image_url;
   }
 
   // Sync Master media URL with the media URL in Metadata.
   public fun sync_media_url<T>(master: &mut Master<T>, metadata: &Metadata<T>) {
+    assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
     master.media_url = metadata.media_url;
   }
 

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -408,7 +408,7 @@ module recrd::master {
   // Lists Master for sale by setting status to ON_SALE. 
   // This allows a Receipt to be issued for a Master.
   // Only users that hold a `Identity` cap object can call this.
-  public fun list<T>(master: &mut Master<T>, _: &Identity) {
+  public fun list<T>( _: &Identity, master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot be set for sale. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeListed);
 
@@ -421,7 +421,7 @@ module recrd::master {
 
   // Unlists Master from market by reverting status to RETAINED.
   // Only users that hold a `Identity` cap object can call this.
-  public fun unlist<T>(master: &mut Master<T>, _: &Identity) {
+  public fun unlist<T>( _: &Identity, master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot revert status to retained. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeRetained);
 

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -22,6 +22,7 @@ module recrd::master {
   const EInvalidMetadataForMaster: u64 = 6;
   const EItemHasBeenClaimed: u64 = 7;
   const ECanOnlyRetainSuspendedItem: u64 = 8;
+  const EUpdateNotAllowed: u64 = 9;
 
   // === Constants ===
   const RETAINED: u8 = 1;
@@ -52,6 +53,8 @@ module recrd::master {
     media_url: String,
     // sale status of master
     sale_status: u8,
+    // whether master resides in RECRD ecosystem
+    exported: bool,
   }
 
   // Master metadata object that will hold all master-related metadata.
@@ -237,6 +240,7 @@ module recrd::master {
       image_url,
       media_url,
       sale_status,
+      exported: false,
     }
   }
 
@@ -251,6 +255,7 @@ module recrd::master {
       image_url: _,
       media_url: _,
       sale_status: _,
+      exported: _,
     } = master;
 
     // Delete the `Master<T>` object and its UID.
@@ -285,6 +290,18 @@ module recrd::master {
     id.delete()
   }
   
+  /// Admin can update the `exported` field in case the `Master` is moved from
+  /// a `Profile` to a user address.
+  public fun export<T>(_: &AdminCap, master: &mut Master<T>) {
+    master.exported = true;
+  }
+
+  /// Update the `exported` field when a `Master` is being brought back into 
+  /// the RECRD ecosystem under a `Profile`.
+  public fun import<T>(_: &AdminCap, master: &mut Master<T>) {
+    master.exported = false;
+  }
+
   // === Master Accessors ===
 
   public fun metadata_ref<T>(master: &Master<T>): &ID {
@@ -458,6 +475,8 @@ module recrd::master {
     master: &Master<T>, metadata: &mut Metadata<T>, title: String
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
+    // Only allow update when Master is in RECRD ecosystem.
+    assert!(master.exported == false, EUpdateNotAllowed);
     metadata.title = title;
   }
 
@@ -467,6 +486,8 @@ module recrd::master {
     master: &Master<T>, metadata: &mut Metadata<T>, description: String
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
+    // Only allow update when Master is in RECRD ecosystem.
+    assert!(master.exported == false, EUpdateNotAllowed);
     metadata.description = description;
   }
 
@@ -476,6 +497,8 @@ module recrd::master {
     master: &Master<T>, metadata: &mut Metadata<T>, image_url: String
   ) {
     assert!(object::id(master) == metadata.master_id, EInvalidMetadataForMaster);
+    // Only allow update when Master is in RECRD ecosystem.
+    assert!(master.exported == false, EUpdateNotAllowed);
     metadata.image_url = image_url;
   }
   

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -405,13 +405,12 @@ module recrd::master {
   public fun list<T>(master: &mut Master<T>) {
     // Masters that are SUSPENDED cannot be set for sale. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeListed);
-
     master.sale_status = ON_SALE;
   }
 
   // Unlists Master from market by reverting status to RETAINED. 
   public fun unlist<T>(master: &mut Master<T>) {
-    // Masters that are SUSPENDED cannot be set reverted to retained. 
+    // Masters that are SUSPENDED cannot revert status to retained. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeRetained);
     master.sale_status = RETAINED;
   }

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -21,6 +21,7 @@ module recrd::master {
   const ESuspendedItemCannotBeRetained: u64 = 5;
   const EInvalidMetadataForMaster: u64 = 6;
   const EItemHasBeenClaimed: u64 = 7;
+  const ECanOnlyRetainSuspendedItem: u64 = 8;
 
   // === Constants ===
   const RETAINED: u8 = 1;
@@ -430,6 +431,12 @@ module recrd::master {
   // Admin can suspend a Master for violation.
   public fun suspend<T>(_: &AdminCap, master: &mut Master<T>) {
     master.sale_status = SUSPENDED;
+  }
+
+  // Admin can unsuspend a Master that was previously suspended.
+  public fun unsuspend<T>(_: &AdminCap, master: &mut Master<T>) {
+    assert!(master.sale_status == SUSPENDED, ECanOnlyRetainSuspendedItem);
+    master.sale_status = RETAINED;
   }
 
   // Internal status to avoid updating of Master while it's in the process of being

--- a/move/sources/master.move
+++ b/move/sources/master.move
@@ -12,7 +12,8 @@ module recrd::master {
   use sui::package;
   use sui::display;
   use recrd::core::AdminCap;
-  
+  use recrd::identity::Identity;
+
   // === Errors ===
   const EHashtagDoesNotExist: u64 = 1;
   const EInvalidNewRevenueTotal: u64 = 2;
@@ -406,7 +407,8 @@ module recrd::master {
 
   // Lists Master for sale by setting status to ON_SALE. 
   // This allows a Receipt to be issued for a Master.
-  public fun list<T>(master: &mut Master<T>) {
+  // Only users that hold a `Identity` cap object can call this.
+  public fun list<T>(master: &mut Master<T>, _: &Identity) {
     // Masters that are SUSPENDED cannot be set for sale. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeListed);
 
@@ -417,8 +419,9 @@ module recrd::master {
     master.sale_status = ON_SALE;
   }
 
-  // Unlists Master from market by reverting status to RETAINED. 
-  public fun unlist<T>(master: &mut Master<T>) {
+  // Unlists Master from market by reverting status to RETAINED.
+  // Only users that hold a `Identity` cap object can call this.
+  public fun unlist<T>(master: &mut Master<T>, _: &Identity) {
     // Masters that are SUSPENDED cannot revert status to retained. 
     assert!(master.sale_status != SUSPENDED, ESuspendedItemCannotBeRetained);
 

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -26,11 +26,10 @@ module recrd::profile {
   const EInvalidSaleStatus: u64 = 1;
   const EInvalidAccessRights: u64 = 2;
   const EInvalidObject: u64 = 3;
-  const EAccessLevelOutOfRange: u64 = 4;
-  const ENotAuthorized: u64 = 5;
-  const EAccessLevelOutOfBounds: u64 = 6;
-  const EMasterNotOnSale: u64 = 7;
-  const EUpdateNotAuthorized: u64 = 8;
+  const ENotAuthorized: u64 = 4;
+  const EAccessLevelOutOfBounds: u64 = 5;
+  const EMasterNotOnSale: u64 = 6;
+  const EUpdateNotAuthorized: u64 = 7;
 
   // === Constants ===
 
@@ -70,7 +69,7 @@ module recrd::profile {
     // type pending to decide the hashing approach
     username: String,
     // Keep a record of each user's address + RECRD address
-	  // in the format of a pair <address, Access Level [0,250]>
+	  // in the format of a pair <address, Access Level [0,255]>
     authorizations: Table<address, u8>,
     // total time the user has spent on watching videos
     watch_time: u64, // in seconds
@@ -137,9 +136,6 @@ module recrd::profile {
   public fun authorize(
     _: &AdminCap, self: &mut Profile, addr: address, access: u8
   ) {
-    // Users access level should be in the range of (0, 200)
-    assert!(access > 0 && access <= 250, EAccessLevelOutOfRange);
-    
     self.authorizations.add(addr, access);
   }
 
@@ -409,9 +405,6 @@ module recrd::profile {
 
   /// Updates the access level of given address in the `Profile` authorization table.
   fun update_authorization_(self: &mut Profile, addr: address, new_access: u8) {
-    // Make sure the new access level is within the allowed range. 
-    assert!(new_access >= 0 && new_access <= 250, EAccessLevelOutOfRange);
-
     // Check whether given address exists in authorization table. 
     assert!(self.authorizations.contains(addr), ENotAuthorized);
 

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -153,7 +153,10 @@ module recrd::profile {
 
     // Cannot borrow during an active selling process where a Receipt has been issued
     // or if master has been suspended for violation.
-    assert!(master.sale_status<T>() != CLAIMED && master.sale_status<T>() != SUSPENDED, EBorrowNotAllowed);
+    assert!(
+      master.sale_status<T>() != CLAIMED && master.sale_status<T>() != SUSPENDED, 
+      EBorrowNotAllowed
+    );
 
     let promise = Promise { 
       master_id: object::id(&master),

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -355,37 +355,37 @@ module recrd::profile {
     self.authorizations.borrow(user)
   }
 
-  // Updates the watch time for given profile.
+  // Returns the watch time for given profile.
   public fun watch_time(self: &Profile): &u64 {
     &self.watch_time
   }
 
-  // Updates the number of videos watched for given profile.
+  // Returns the number of videos watched for given profile.
   public fun videos_watched(self: &Profile): &u64 {
     &self.videos_watched
   }
 
-  // Updates the number of adverts watched for given profile.
+  // Returns the number of adverts watched for given profile.
   public fun adverts_watched(self: &Profile): &u64 {
     &self.adverts_watched
   }
   
-  // Updates the number of followers for given profile.
+  // Returns the number of followers for given profile.
   public fun number_of_followers(self: &Profile): &u64 {
     &self.number_of_followers
   }
 
-  // Updates the number users given profile is following.
+  // Returns the number users given profile is following.
   public fun number_of_following(self: &Profile): &u64 {
     &self.number_of_following
   }
 
-  // Updates the ad revenue for given profile.
+  // Returns the ad revenue for given profile.
   public fun ad_revenue(self: &Profile): &u64 {
     &self.ad_revenue
   }
   
-  // Updates the commission revenue for given profile.
+  // Returns the commission revenue for given profile.
   public fun commission_revenue(self: &Profile): &u64 {
     &self.commission_revenue
   }

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -75,7 +75,7 @@ module recrd::profile {
     authorizations: Table<address, u8>,
     // total time the user has spent on watching videos
     watch_time: u64, // in seconds
-    // (TBD) dynamic fields for every video watched
+    // Number of videos watched
     videos_watched: u64,
 	  // Number of adverts seen
 	  adverts_watched: u64,

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -152,7 +152,8 @@ module recrd::profile {
     let master = self.receive_master_<T>(master);
 
     // Cannot borrow during an active selling process where a Receipt has been issued
-    assert!(master.sale_status<T>() != CLAIMED, EBorrowNotAllowed);
+    // or if master has been suspended for violation.
+    assert!(master.sale_status<T>() != CLAIMED && master.sale_status<T>() != SUSPENDED, EBorrowNotAllowed);
 
     let promise = Promise { 
       master_id: object::id(&master),

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -157,17 +157,8 @@ module recrd::profile {
   public fun borrow_master<T: drop>(
     self: &mut Profile, master: Receiving<Master<T>>, ctx: &mut TxContext
   ): (Master<T>, Promise) {
-    // Check whether sender exists in authorization table. 
-    assert!(
-      self.authorizations.contains(ctx.sender()),
-      ENotAuthorized
-    );
-
     // Users that have access above the BORROW_ACCESS threshold can borrow the master
-    assert!(
-      *self.authorizations.borrow(ctx.sender()) >= BORROW_ACCESS,
-      EInvalidAccessRights
-    );
+    assert!(*self.access_rights(ctx.sender()) >= BORROW_ACCESS, EInvalidAccessRights);
 
     let master = self.receive_master_<T>(master);
 

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -125,7 +125,7 @@ module recrd::profile {
     transfer::transfer(identity, addr);
   }
 
-  /// Admin can send more Identitys to users that have existing Profile. 
+  /// Admin can send more Identities to users that have existing Profile. 
   public fun new_cap(
     _: &AdminCap, profile: &Profile, ctx: &mut TxContext
   ): Identity {
@@ -146,11 +146,11 @@ module recrd::profile {
     self.authorizations.remove(user);
   }
 
-  /// Admin can receive any `T` object from `Profile`.
-  public fun admin_receive<T: key + store>(
-    _:&AdminCap, self: &mut Profile, object: Receiving<T>
-  ): T {
-    transfer::public_receive<T>(&mut self.id, object)
+  /// Admin can receive `Master<T>` from a profile.
+  public fun admin_receive_master<T: drop>(
+    _:&AdminCap, self: &mut Profile, master: Receiving<Master<T>>
+  ): Master<T> {
+    self.receive_master_<T>(master)
   }
 
   /// Borrows Master<T> temporarily with a Promise to return it back. 

--- a/move/sources/profile.move
+++ b/move/sources/profile.move
@@ -217,9 +217,6 @@ module recrd::profile {
 
   // Authorized addresses can update username.
   public fun update_username(self: &mut Profile, new_username: String, ctx: &mut TxContext) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     
@@ -230,9 +227,6 @@ module recrd::profile {
   public fun update_watch_time(
     self: &mut Profile, new_watch_time: u64, ctx: &mut TxContext
   ) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     
@@ -246,9 +240,6 @@ module recrd::profile {
   public fun update_videos_watched(
     self: &mut Profile, new_videos_watched: u64, ctx: &mut TxContext
   ) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     
@@ -262,9 +253,6 @@ module recrd::profile {
   public fun update_adverts_watched(
     self: &mut Profile, new_adverts_watched: u64, ctx: &mut TxContext
   ) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     
@@ -278,9 +266,6 @@ module recrd::profile {
   public fun update_number_of_followers( 
     self: &mut Profile, new_number_of_followers: u64, ctx: &mut TxContext
   ) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     
@@ -291,9 +276,6 @@ module recrd::profile {
   public fun update_number_of_following(
     self: &mut Profile, new_number_of_following: u64, ctx: &mut TxContext
   ) {
-    // Only addresses in the authorizations table can update.
-    assert!(self.authorizations.contains(ctx.sender()), ENotAuthorized);
-
     // Only addresses with minimum UPDATE_ACCESS can update. 
     assert!(*self.access_rights(ctx.sender()) >= UPDATE_ACCESS, EUpdateNotAuthorized);
     

--- a/move/sources/receipt.move
+++ b/move/sources/receipt.move
@@ -55,7 +55,7 @@ module recrd::receipt {
 
         transfer::transfer(Receipt {
             id: object::new(ctx),
-            master_id: master::id<T>(master),
+            master_id: object::id<Master<T>>(master),
             user_profile: profile,
         }, profile);
     }

--- a/move/sources/receipt.move
+++ b/move/sources/receipt.move
@@ -9,9 +9,14 @@ module recrd::receipt {
     // === Imports ===
     use sui::transfer::{Receiving};
     use recrd::core::{AdminCap, Registry};
+    use recrd::master::{Self, Master};
 
     // === Errors ===
     const EWrongVersion: u64 = 1;
+    const EMasterNotOnSale: u64 = 2;
+
+    // On sale state is when the master is on sale
+    const ON_SALE: u8 = 2;
 
     // === Structs ===
     public struct Receipt has key {
@@ -23,14 +28,16 @@ module recrd::receipt {
     /// Users who buy a `Master<T>` object will receive a receipt as proof of purchase 
     /// sent to their profile. The receipt contains the `master_id` and `user_profile` 
     /// of the purchase.
-    /// We include the `master_id` to allow the user to move the `Master<T>` object 
-    /// to another profile.
+    /// We require the `Master<T>` object of interest as an argument in order to 
+    /// update its status to CLAIMED since the buyer has paid for it already, and
+    /// we also include the Master ID in the `Receipt` so that the user will be able
+    /// to successfully claim the Master upon completing the purchase.
     /// The `user_profile` is the Profile address of the user who made the purchase.
     /// We include the `user_profile` so that `Master<T>` is transferred to the 
     /// correct profile.
-    public fun new(
+    public fun new<T>(
         _: &AdminCap, 
-        master_id: ID, 
+        master: &mut Master<T>, 
         profile: address, 
         registry: &Registry, 
         ctx: &mut TxContext
@@ -38,10 +45,17 @@ module recrd::receipt {
         // Don't allow the issuance of new receipts if the core VERSION is not the same
         // with the version on Registry.
         assert!(registry.is_valid_version(), EWrongVersion);
+        
+        // Issue a Receipt for Master only if its status is ON_SALE
+        assert!(master.sale_status<T>() == ON_SALE, EMasterNotOnSale);
+
+        // Update Master status to CLAIMED to halt further updates until selling and
+        // `Receipt` resolution is completed.
+        master::claim<T>(master);
 
         transfer::transfer(Receipt {
             id: object::new(ctx),
-            master_id,
+            master_id: master::id<T>(master),
             user_profile: profile,
         }, profile);
     }

--- a/move/tests/identity_test.move
+++ b/move/tests/identity_test.move
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module recrd::identity_test {
+  // === Imports ===
+  use std::string::utf8;
+  use sui::test_scenario as ts;
+
+  use recrd::core::{Self};
+  use recrd::profile::{Self, Profile};
+  use recrd::identity;
+  
+  // === Constants ===
+  const ADMIN: address = @0xDECAF;
+  const USER: address = @0xB00;
+  const USER_PROFILE: address = @0xC0FFEE;
+  const USERNAME: vector<u8> = b"username";
+  const USER_ID: vector<u8> = b"user_id";
+
+  #[test]
+  public fun admin_mints_and_transfers_identity() {
+    let mut scenario = ts::begin(ADMIN);
+    let admin_cap = core::mint_for_testing(ts::ctx(&mut scenario));
+
+    // Create Profile for user
+    ts::next_tx(&mut scenario, ADMIN);
+    {
+      profile::new(
+          &admin_cap, 
+          utf8(USER_ID), 
+          utf8(USERNAME), 
+          USER,
+          ts::ctx(&mut scenario)
+      );
+    };
+    
+    ts::next_tx(&mut scenario, ADMIN);
+    {
+      let profile = ts::take_shared<Profile>(&scenario);
+      let identity = identity::admin_new(&admin_cap, object::id(&profile), ts::ctx(&mut scenario));
+      identity::admin_transfer(&admin_cap, identity, USER);
+      ts::return_shared(profile);
+    };
+
+   
+    core::burn_admincap(admin_cap);
+    ts::end(scenario);
+  }
+
+  #[test]
+  public fun burns_identity() {
+    let mut scenario = ts::begin(ADMIN);
+
+    let identity = identity::create_for_testing(
+      object::id_from_address(USER_PROFILE), 
+      ts::ctx(&mut scenario)
+    );
+
+    identity::burn(identity);
+    ts::end(scenario);
+  }
+}

--- a/move/tests/identity_test.move
+++ b/move/tests/identity_test.move
@@ -14,7 +14,6 @@ module recrd::identity_test {
   // === Constants ===
   const ADMIN: address = @0xDECAF;
   const USER: address = @0xB00;
-  const USER_PROFILE: address = @0xC0FFEE;
   const USERNAME: vector<u8> = b"username";
   const USER_ID: vector<u8> = b"user_id";
 
@@ -45,19 +44,6 @@ module recrd::identity_test {
 
    
     core::burn_admincap(admin_cap);
-    ts::end(scenario);
-  }
-
-  #[test]
-  public fun burns_identity() {
-    let mut scenario = ts::begin(ADMIN);
-
-    let identity = identity::create_for_testing(
-      object::id_from_address(USER_PROFILE), 
-      ts::ctx(&mut scenario)
-    );
-
-    identity::burn(identity);
     ts::end(scenario);
   }
 }

--- a/move/tests/master_test.move
+++ b/move/tests/master_test.move
@@ -406,7 +406,7 @@ module recrd::master_test {
         ts::next_tx(&mut scenario, USER);
         {
             let identity = ts::take_from_sender<Identity>(&scenario);
-            master::unlist(&mut master, &identity);
+            master::unlist(&identity, &mut master);
             ts::return_to_sender(&scenario, identity);
         };
 
@@ -684,7 +684,7 @@ module recrd::master_test {
         {
             // User tries to list for sale
             let identity = ts::take_from_sender<Identity>(&scenario);
-            master::list(&mut master, &identity);
+            master::list(&identity, &mut master);
             ts::return_to_sender(&scenario, identity);
         };
 
@@ -737,7 +737,7 @@ module recrd::master_test {
         {
             // User tries to list for sale
             let identity = ts::take_from_sender<Identity>(&scenario);
-            master::unlist(&mut master, &identity);
+            master::unlist(&identity, &mut master);
             ts::return_to_sender(&scenario, identity);
         };
 

--- a/move/tests/master_test.move
+++ b/move/tests/master_test.move
@@ -416,10 +416,10 @@ module recrd::master_test {
         {
             let mut metadata = ts::take_shared<Metadata<Video>>(&scenario);
             
-            master::set_title(&mut metadata, utf8(b"Updated Title"));
-            master::set_description(&mut metadata, utf8(b"Updated Description"));
+            master::set_title(&master, &mut metadata, utf8(b"Updated Title"));
+            master::set_description(&master, &mut metadata, utf8(b"Updated Description"));
             master::set_hashtags(&admin_cap, &mut metadata, vector[utf8(b"updated"), utf8(b"master")]);
-            master::set_image_url(&mut metadata, utf8(b"image-url.com"));
+            master::set_image_url(&master, &mut metadata, utf8(b"image-url.com"));
             master::set_media_url(&admin_cap, &mut metadata, utf8(b"media-url.com"));
             master::set_royalty_percentage_bp(&admin_cap, &mut metadata, 200);
             master::set_metadata_parent(&admin_cap, &mut metadata, option::none<ID>());
@@ -756,7 +756,7 @@ module recrd::master_test {
         // Update Metadata
         ts::next_tx(&mut scenario, ADMIN);
         {
-            master::set_title<Video>(&mut metadata, utf8(b"A New title"));
+            master::set_title<Video>(&master, &mut metadata, utf8(b"A New title"));
         };
 
         let _impostor_master = mint_master<Video>(

--- a/move/tests/master_test.move
+++ b/move/tests/master_test.move
@@ -10,7 +10,7 @@ module recrd::master_test {
     use sui::vec_map::{Self};
 
     use recrd::core::{Self};
-    use recrd::identity::{Self, Identity};
+    use recrd::identity;
     use recrd::profile::{Self, Profile};
     use recrd::master::{
         Self, 
@@ -405,9 +405,7 @@ module recrd::master_test {
 
         ts::next_tx(&mut scenario, USER);
         {
-            let identity = ts::take_from_sender<Identity>(&scenario);
-            master::unlist(&identity, &mut master);
-            ts::return_to_sender(&scenario, identity);
+            master::unlist(&mut master);
         };
 
         // Validate Updated sale status
@@ -683,9 +681,7 @@ module recrd::master_test {
         ts::next_tx(&mut scenario, USER);
         {
             // User tries to list for sale
-            let identity = ts::take_from_sender<Identity>(&scenario);
-            master::list(&identity, &mut master);
-            ts::return_to_sender(&scenario, identity);
+            master::list(&mut master);
         };
 
         master::burn_master(&admin_cap, master);
@@ -736,9 +732,7 @@ module recrd::master_test {
         ts::next_tx(&mut scenario, USER);
         {
             // User tries to list for sale
-            let identity = ts::take_from_sender<Identity>(&scenario);
-            master::unlist(&identity, &mut master);
-            ts::return_to_sender(&scenario, identity);
+            master::unlist(&mut master);
         };
 
         master::burn_master(&admin_cap, master);

--- a/move/tests/profile_test.move
+++ b/move/tests/profile_test.move
@@ -83,9 +83,6 @@ module recrd::profile_test {
         ts::end(scenario);
     }
 
-    // @TODO: For max testing coverage (even though I am pretty sure the actual coverage
-    // tool doesn't check possible values in the numbers range), 
-    // should we also check that the admin can successfully be assigned the REMOVE_ACCESS?
     #[test]
     public fun admin_authorizes_address() {
         let mut scenario = ts::begin(ADMIN);
@@ -105,55 +102,6 @@ module recrd::profile_test {
 
         ts::end(scenario);
     }
-
-    #[test]
-    public fun admin_receives() {
-        let mut scenario = ts::begin(ADMIN);
-
-        create_profile(&mut scenario);
-
-        // --- Authorize admin to receive ---
-        ts::next_tx(&mut scenario, ADMIN);
-        {
-            let mut profile = ts::take_shared<Profile>(&scenario);
-            authorize_user(&mut scenario, &mut profile, ADMIN, 1);
-            ts::return_shared(profile);
-        };
-
-        // --- Create a master and send it to the profile ---
-        // let master_id;
-        ts::next_tx(&mut scenario, ADMIN);
-        {
-            let master = master_test::mint_master<Video>(
-                &mut scenario,
-                utf8(b"Test Video Master"),
-                option::none<ID>(),
-                option::none<ID>()
-            );
-
-            // master_id = object::id(&master);
-            let profile = ts::take_shared<Profile>(&scenario);
-            transfer::public_transfer(master, object::id_address(&profile));
-            ts::return_shared(profile);
-        };
-
-        // --- Admin receives the master & burns it ---
-        // @TODO: add in the TS integration tests, receiving can not be tested in Move yet (ref: https://mysten-labs.slack.com/archives/C04J99F4B2L/p1702672648821549?thread_ts=1702652736.041159&cid=C04J99F4B2L)
-        // ts::next_tx(test, ADMIN);
-        // {
-        //     let ctx = ts::ctx(test);
-        //     let profile = ts::take_shared<Profile>(test);
-        //     let receiving_arg = Receiving<Master<Video>> {
-        //         id: master_id,
-        //         version: 0
-        //     };
-        //     let master = profile::receive_master<Master<Video>>(&mut profile, receiving_arg, ctx);
-        // };
-
-        ts::end(scenario);
-    }
-
-    // @TODO: same is true as above for borrow_master, return_master & buy. To be added as TS integration tests
 
     #[test]
     public fun admin_updates_profile_fields() {

--- a/move/tests/profile_test.move
+++ b/move/tests/profile_test.move
@@ -6,8 +6,9 @@ module recrd::profile_test {
     use sui::test_scenario::{Self as ts, Scenario};
 
     use recrd::core::{Self};
-    use recrd::profile::{Self, Profile, Identity, ENewValueShouldBeHigher, ENotAuthorized};
+    use recrd::profile::{Self, Profile, ENewValueShouldBeHigher, ENotAuthorized};
     use recrd::master::{Video};
+    use recrd::identity::{Identity};
     use recrd::master_test;
 
     // === Constants ===

--- a/move/tests/profile_test.move
+++ b/move/tests/profile_test.move
@@ -6,7 +6,7 @@ module recrd::profile_test {
     use sui::test_scenario::{Self as ts, Scenario};
 
     use recrd::core::{Self};
-    use recrd::profile::{Self, Profile, Identity, EAccessLevelOutOfRange, ENewValueShouldBeHigher, ENotAuthorized};
+    use recrd::profile::{Self, Profile, Identity, ENewValueShouldBeHigher, ENotAuthorized};
     use recrd::master::{Video};
     use recrd::master_test;
 
@@ -195,25 +195,6 @@ module recrd::profile_test {
     }
 
     // === Expected failures ===
-    #[test]
-    #[expected_failure(abort_code = EAccessLevelOutOfRange)]
-    public fun admin_authorizes_address_with_invalid_u8(){
-        let mut scenario = ts::begin(ADMIN);
-        let test = &mut scenario;
-
-        create_profile(test);
-
-        // --- Authorize user with an invalid role ---
-        ts::next_tx(test, ADMIN);
-        {
-            let mut profile = ts::take_shared<Profile>(test);
-            authorize_user(test, &mut profile, USER_PROFILE, 0);
-            ts::return_shared(profile);
-        };
-
-        ts::end(scenario);
-    }
-
     #[test]
     #[expected_failure(abort_code = ENewValueShouldBeHigher)]
     public fun updates_watch_time_with_invalid_value() {

--- a/move/tests/receipt_test.move
+++ b/move/tests/receipt_test.move
@@ -2,13 +2,17 @@
 module recrd::receipt_test {
     // === Imports ===
     use sui::test_scenario::{Self as ts};
+    use std::string::{utf8};
     use recrd::core;
+    use recrd::master::{Self, Sound};
     use recrd::receipt::{Self, Receipt};
+    use recrd::master_test;
 
     // === Constants ===
     const ADMIN: address = @0xDECAF;
-    const USER: address = @0xFACE;
-    const MASTER_ID: address = @0xC0FFEE;
+    const USER: address = @0xC0FFEE;
+    const ORIGIN_REF: address = @0xFACE;
+    const PARENT_REF: address = @0xBEEF;
 
     // === Errors ===
     const EInvalidMasterId: u64 = 1001;
@@ -21,13 +25,23 @@ module recrd::receipt_test {
         core::init_for_testing(ts::ctx(&mut scenario));
         let admin_cap = core::mint_for_testing(ts::ctx(&mut scenario));
 
+        // Mint Master
+        let mut master = master_test::mint_master<Sound>(
+            &mut scenario,
+            utf8(b"Test Sound Master"),
+            option::some<ID>(object::id_from_address(PARENT_REF)),
+            option::some<ID>(object::id_from_address(ORIGIN_REF))
+        );
+
+        let master_id = master.id<Sound>();
+
         // Admin creates a new receipt for user
         ts::next_tx(&mut scenario, ADMIN);
         {
             let registry = ts::take_shared<core::Registry>(&scenario);
             receipt::new(
                 &admin_cap, 
-                object::id_from_address(MASTER_ID), 
+                &mut master, 
                 USER, 
                 &registry, 
                 ts::ctx(&mut scenario)
@@ -40,10 +54,11 @@ module recrd::receipt_test {
         {
             let receipt = ts::take_from_sender<Receipt>(&scenario);
             let (id, address) = receipt::burn(receipt);
-            assert!(id == object::id_from_address(MASTER_ID), EInvalidMasterId);
+            assert!(id == master_id, EInvalidMasterId);
             assert!(address == USER, EInvalidMasterId);
         };
 
+        let _ = master::burn_master(&admin_cap, master);
         core::burn_admincap(admin_cap);
         ts::end(scenario);
     }

--- a/move/tests/receipt_test.move
+++ b/move/tests/receipt_test.move
@@ -4,7 +4,7 @@ module recrd::receipt_test {
     use sui::test_scenario::{Self as ts};
     use std::string::{utf8};
     use recrd::core;
-    use recrd::master::{Self, Sound};
+    use recrd::master::{Self, Master, Sound};
     use recrd::receipt::{Self, Receipt};
     use recrd::master_test;
 
@@ -33,7 +33,7 @@ module recrd::receipt_test {
             option::some<ID>(object::id_from_address(ORIGIN_REF))
         );
 
-        let master_id = master.id<Sound>();
+        let master_id = object::id<Master<Sound>>(&master);
 
         // Admin creates a new receipt for user
         ts::next_tx(&mut scenario, ADMIN);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "updateDisplay": "ts-node src/updateDisplay.ts",
     "testProfileNew": "ts-node src/tests/profile/testProfileNew.ts",
     "testProfileAuthorize": "ts-node src/tests/profile/testProfileAuthorize.ts",
     "testProfileDeauthorize": "ts-node src/tests/profile/testProfileDeauthorize.ts",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,8 @@
     "testMasterBuy": "ts-node src/tests/master/testMasterBuy.ts",
     "testMasterSetOnSale": "ts-node src/tests/master/testMasterSetOnSale.ts",
     "testMasterRetain": "ts-node src/tests/master/testMasterRetain.ts",
-    "testMasterSuspend": "ts-node src/tests/master/testMasterSuspend.ts"
+    "testMasterSuspend": "ts-node src/tests/master/testMasterSuspend.ts",
+    "testMasterUnsuspend": "ts-node src/tests/master/testMasterUnsuspend.ts"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,6 +13,7 @@
     "testMasterReceiveAndBurn": "ts-node src/tests/master/testMasterReceiveAndBurn.ts",
     "testGetMaster": "ts-node src/tests/master/testGetMaster.ts",
     "testGetMasterMetadata": "ts-node src/tests/master/testGetMasterMetadata.ts",
+    "testMetadataSetTitleAndSync": "ts-node src/tests/master/testMetadataSetTitleAndSync.ts",
     "testMasterMetadataBurn": "ts-node src/tests/master/testMasterMetadataBurn.ts",
     "testReceiptMint": "ts-node src/tests/receipt/testReceiptMint.ts",
     "testMasterBuy": "ts-node src/tests/master/testMasterBuy.ts",

--- a/scripts/src/config.ts
+++ b/scripts/src/config.ts
@@ -39,6 +39,7 @@ export const SALE_STATUS = {
   RETAINED: 1,
   ON_SALE: 2,
   SUSPENDED: 3,
+  CLAIMED: 4,
 };
 
 export const VIDEO_TYPE = `${PACKAGE_ID}::master::Video`;

--- a/scripts/src/config.ts
+++ b/scripts/src/config.ts
@@ -40,6 +40,7 @@ export const SALE_STATUS = {
   ON_SALE: 2,
   SUSPENDED: 3,
   CLAIMED: 4,
+  UNSUSPEND: 5, // ATTENTION: This is a custom status only used for the TS tests to differentiate between states. It does not exist in the contract sale statuses.
 };
 
 export const VIDEO_TYPE = `${PACKAGE_ID}::master::Video`;

--- a/scripts/src/config.ts
+++ b/scripts/src/config.ts
@@ -14,6 +14,7 @@ config({
 // Load the environment variables
 export const SUI_NETWORK = process.env.SUI_NETWORK!;
 export const PACKAGE_ID = process.env.RECRD_PACKAGE_ID!;
+export const DIGEST = process.env.DIGEST!;
 export const ADMIN_CAP = process.env.CORE_ADMIN_CAP!;
 export const PUBLISHER = process.env.MASTER_PUBLISHER!;
 export const REGISTRY = process.env.REGISTRY!;
@@ -44,7 +45,11 @@ export const SALE_STATUS = {
 };
 
 export const VIDEO_TYPE = `${PACKAGE_ID}::master::Video`;
-export const AUDIO_TYPE = `${PACKAGE_ID}::master::Audio`;
+export const SOUND_TYPE = `${PACKAGE_ID}::master::Sound`;
+export const MASTER_VIDEO_TYPE = `${PACKAGE_ID}::master::Master<${VIDEO_TYPE}>`;
+export const MASTER_SOUND_TYPE = `${PACKAGE_ID}::master::Master<${SOUND_TYPE}>`;
+export const METADATA_VIDEO_TYPE = `${PACKAGE_ID}::master::Metadata<${VIDEO_TYPE}>`;
+export const METADATA_SOUND_TYPE = `${PACKAGE_ID}::master::Metadata<${SOUND_TYPE}>`;
 export const LOYALTY_FREE_URL =
   "https://images.pexels.com/photos/19987062/pexels-photo-19987062/free-photo-of-a-close-up-of-pink-flowers-in-a-field.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2";
 

--- a/scripts/src/modules/MasterModule.ts
+++ b/scripts/src/modules/MasterModule.ts
@@ -7,7 +7,13 @@ import {
   TransactionResult,
 } from "@mysten/sui.js/transactions";
 import { executeTransaction, getMasterT, getMasterMetadataT } from "../utils";
-import { PACKAGE_ID, ADMIN_CAP, suiClient } from "../config";
+import {
+  PACKAGE_ID,
+  ADMIN_CAP,
+  suiClient,
+  VIDEO_TYPE,
+  SOUND_TYPE,
+} from "../config";
 import { SUI_FRAMEWORK_ADDRESS } from "@mysten/sui.js/utils";
 import { Master, MasterMetadata } from "../interfaces";
 import { Signer } from "@mysten/sui.js/cryptography";
@@ -36,9 +42,6 @@ interface mintMasterResponse {
   master: SuiObjectChangeCreated | undefined;
   metadata: SuiObjectChangeCreated | undefined;
 }
-
-export const VIDEO_TYPE = `${PACKAGE_ID}::master::Video`;
-export const AUDIO_TYPE = `${PACKAGE_ID}::master::Audio`;
 
 export class MasterModule {
   /**
@@ -115,7 +118,7 @@ export class MasterModule {
         txb.pure(params.revenue_pending),
         txb.pure(params.sale_status),
       ],
-      typeArguments: [params.type === "Video" ? VIDEO_TYPE : AUDIO_TYPE],
+      typeArguments: [params.type === "Video" ? VIDEO_TYPE : SOUND_TYPE],
     });
 
     txb.transferObjects([masterTx], params.creator_profile_id);

--- a/scripts/src/modules/ProfileModule.ts
+++ b/scripts/src/modules/ProfileModule.ts
@@ -336,13 +336,13 @@ export class ProfileModule {
 
     // Call the smart contract function to receive a Master object
     let master = txb.moveCall({
-      target: `${PACKAGE_ID}::profile::admin_receive`,
+      target: `${PACKAGE_ID}::profile::admin_receive_master`,
       arguments: [
         txb.object(ADMIN_CAP),
         txb.object(profileId),
         txb.object(masterId),
       ],
-      typeArguments: [`${PACKAGE_ID}::master::Master<${masterType}>`],
+      typeArguments: [masterType!],
     });
 
     // Get the Sui address of the signer

--- a/scripts/src/modules/ProfileModule.ts
+++ b/scripts/src/modules/ProfileModule.ts
@@ -355,7 +355,11 @@ export class ProfileModule {
       arguments: [
         txb.object(ADMIN_CAP),
         txb.object(profileId),
-        txb.object(masterId),
+        txb.receivingRef({
+          digest: masterRes.data?.digest!,
+          objectId: masterId,
+          version: masterRes.data?.version!,
+        }),
       ],
       typeArguments: [masterType!],
     });

--- a/scripts/src/modules/ProfileModule.ts
+++ b/scripts/src/modules/ProfileModule.ts
@@ -40,7 +40,10 @@ export class ProfileModule {
     username: string,
     userAddress: string,
     signer: Signer
-  ): Promise<SuiObjectChangeCreated> {
+  ): Promise<{
+    profile: SuiObjectChangeCreated;
+    identity: SuiObjectChangeCreated;
+  }> {
     // Create a transaction block
     const txb = new TransactionBlock();
 
@@ -65,7 +68,7 @@ export class ProfileModule {
       );
     }
 
-    return response.objectChanges?.find((object) => {
+    const profileRes = response.objectChanges?.find((object) => {
       return (
         object.type === "created" &&
         object.objectType.startsWith(`${PACKAGE_ID}::profile::Profile`)
@@ -77,6 +80,18 @@ export class ProfileModule {
           initial_shared_version: string;
         };
       };
+    };
+
+    const identityRes = response.objectChanges?.find((object) => {
+      return (
+        object.type === "created" &&
+        object.objectType.startsWith(`${PACKAGE_ID}::identity::Identity`)
+      );
+    }) as SuiObjectChangeCreated;
+
+    return {
+      profile: profileRes,
+      identity: identityRes,
     };
   }
 

--- a/scripts/src/modules/ReceiptModule.ts
+++ b/scripts/src/modules/ReceiptModule.ts
@@ -4,27 +4,61 @@
 import { Signer } from "@mysten/sui.js/cryptography";
 import { SuiObjectChangeCreated } from "@mysten/sui.js/client";
 import { TransactionBlock } from "@mysten/sui.js/transactions";
-import { ADMIN_CAP, PACKAGE_ID, REGISTRY } from "../config";
-import { executeTransaction } from "../utils";
+import { ADMIN_CAP, PACKAGE_ID, REGISTRY, suiClient } from "../config";
+import { executeTransaction, getMasterT } from "../utils";
 
 export class ReceiptModule {
   /// Issue a new Receipt for user that wants to buy a Master
   async newReceipt(
     masterId: string,
-    profileId: string,
+    buyerProfileId: string,
+    sellerProfileId: string,
     signer: Signer
   ): Promise<SuiObjectChangeCreated> {
     // Create a transaction block
     const txb = new TransactionBlock();
 
+    const masterRes = await suiClient.getObject({
+      id: masterId,
+      options: { showContent: true },
+    });
+
+    const content: any = masterRes.data?.content;
+    const masterType = getMasterT(content.type);
+
+    // First, we need to borrow the Master from the Profile of the seller.
+    let [master, promise] = txb.moveCall({
+      target: `${PACKAGE_ID}::profile::borrow_master`,
+      arguments: [
+        txb.object(sellerProfileId),
+        txb.receivingRef({
+          digest: masterRes.data?.digest!,
+          objectId: masterId,
+          version: masterRes.data?.version!,
+        }),
+      ],
+      typeArguments: [masterType!],
+    });
+
+    // We invoke the receipt::new function and pass the master as a witness.
+    // The invocation of this function assumes that the buyer has paid off chain.
+    // Therefore the BE is responsible for validating the payment and creating the receipt.
     txb.moveCall({
       target: `${PACKAGE_ID}::receipt::new`,
       arguments: [
         txb.object(ADMIN_CAP),
-        txb.pure(masterId),
-        txb.pure(profileId),
+        master,
+        txb.pure(buyerProfileId),
         txb.object(REGISTRY),
       ],
+      typeArguments: [masterType!],
+    });
+
+    // Return the updated Master object to the Profile and resolve the promise.
+    txb.moveCall({
+      target: `${PACKAGE_ID}::profile::return_master`,
+      arguments: [txb.object(master), promise],
+      typeArguments: [masterType!],
     });
 
     // Sign and execute the transaction as the admin

--- a/scripts/src/tests/master/testMasterRetain.ts
+++ b/scripts/src/tests/master/testMasterRetain.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RECRD_PRIVATE_KEY } from "../../config";
+import { USER_PRIVATE_KEY } from "../../config";
 import { MasterModule } from "../../modules/MasterModule";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -16,16 +16,25 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
+    // Get last created Identity ID from temp file
+    const identityId = readFileSync(
+      join(__dirname, "..", "tempIdentityId.txt"),
+      {
+        encoding: "utf-8",
+      }
+    );
+
     // Get last minted Master ID from temp file
     const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
       encoding: "utf-8",
     });
 
-    // Profile will need to have at least BORROW_ACCESS level of access.
+    // Removing a master from sale to retained can only be performed by the user.
     const res = await masterModule.retainMaster(
       profileId,
+      identityId,
       masterId,
-      getSigner(RECRD_PRIVATE_KEY)
+      getSigner(USER_PRIVATE_KEY)
     );
     console.log("Master status updated successfully:", res);
   } catch (error) {

--- a/scripts/src/tests/master/testMasterRetain.ts
+++ b/scripts/src/tests/master/testMasterRetain.ts
@@ -16,14 +16,6 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
-    // Get last created Identity ID from temp file
-    const identityId = readFileSync(
-      join(__dirname, "..", "tempIdentityId.txt"),
-      {
-        encoding: "utf-8",
-      }
-    );
-
     // Get last minted Master ID from temp file
     const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
       encoding: "utf-8",
@@ -32,7 +24,6 @@ import { getSigner } from "../../utils";
     // Removing a master from sale to retained can only be performed by the user.
     const res = await masterModule.retainMaster(
       profileId,
-      identityId,
       masterId,
       getSigner(USER_PRIVATE_KEY)
     );

--- a/scripts/src/tests/master/testMasterSetOnSale.ts
+++ b/scripts/src/tests/master/testMasterSetOnSale.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RECRD_PRIVATE_KEY } from "../../config";
+import { USER_PRIVATE_KEY } from "../../config";
 import { MasterModule } from "../../modules/MasterModule";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -16,16 +16,25 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
+    // Get last created Identity ID from temp file
+    const identityId = readFileSync(
+      join(__dirname, "..", "tempIdentityId.txt"),
+      {
+        encoding: "utf-8",
+      }
+    );
+
     // Get last minted Master ID from temp file
     const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
       encoding: "utf-8",
     });
 
-    // Profile will need to have at least BORROW_ACCESS level of access.
+    // Listing a master for sale can only be performed by the user.
     const res = await masterModule.listMaster(
       profileId,
+      identityId,
       masterId,
-      getSigner(RECRD_PRIVATE_KEY)
+      getSigner(USER_PRIVATE_KEY)
     );
     console.log("Master status updated successfully:", res);
   } catch (error) {

--- a/scripts/src/tests/master/testMasterSetOnSale.ts
+++ b/scripts/src/tests/master/testMasterSetOnSale.ts
@@ -16,14 +16,6 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
-    // Get last created Identity ID from temp file
-    const identityId = readFileSync(
-      join(__dirname, "..", "tempIdentityId.txt"),
-      {
-        encoding: "utf-8",
-      }
-    );
-
     // Get last minted Master ID from temp file
     const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
       encoding: "utf-8",
@@ -32,7 +24,6 @@ import { getSigner } from "../../utils";
     // Listing a master for sale can only be performed by the user.
     const res = await masterModule.listMaster(
       profileId,
-      identityId,
       masterId,
       getSigner(USER_PRIVATE_KEY)
     );

--- a/scripts/src/tests/master/testMasterSuspend.ts
+++ b/scripts/src/tests/master/testMasterSuspend.ts
@@ -21,7 +21,7 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
-    // Profile will need to have at least BORROW_ACCESS level of access.
+    // Admin restricted operation.
     const res = await masterModule.suspendMaster(
       profileId,
       masterId,

--- a/scripts/src/tests/master/testMasterUnsuspend.ts
+++ b/scripts/src/tests/master/testMasterUnsuspend.ts
@@ -21,7 +21,7 @@ import { getSigner } from "../../utils";
       encoding: "utf-8",
     });
 
-    // Profile will need to have at least BORROW_ACCESS level of access.
+    // Admin restricted operation.
     const res = await masterModule.unsuspendMaster(
       profileId,
       masterId,

--- a/scripts/src/tests/master/testMasterUnsuspend.ts
+++ b/scripts/src/tests/master/testMasterUnsuspend.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RECRD_PRIVATE_KEY } from "../../config";
+import { MasterModule } from "../../modules/MasterModule";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { getSigner } from "../../utils";
+
+(async () => {
+  try {
+    const masterModule = new MasterModule();
+
+    // Get last created Profile ID from temp file
+    const profileId = readFileSync(join(__dirname, "..", "tempProfileId.txt"), {
+      encoding: "utf-8",
+    });
+
+    // Get last minted Master ID from temp file
+    const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
+      encoding: "utf-8",
+    });
+
+    // Profile will need to have at least BORROW_ACCESS level of access.
+    const res = await masterModule.unsuspendMaster(
+      profileId,
+      masterId,
+      getSigner(RECRD_PRIVATE_KEY)
+    );
+    console.log("Master status updated successfully:", res);
+  } catch (error) {
+    console.error("Failed to retain Master:", error);
+  }
+})();

--- a/scripts/src/tests/master/testMetadataSetTitleAndSync.ts
+++ b/scripts/src/tests/master/testMetadataSetTitleAndSync.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RECRD_PRIVATE_KEY } from "../../config";
+import { MasterModule } from "../../modules/MasterModule";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { getSigner } from "../../utils";
+
+(async () => {
+  try {
+    const masterModule = new MasterModule();
+
+    // Get last minted Master ID from temp file
+    const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
+      encoding: "utf-8",
+    });
+
+    // Get last minted Master Metadata ID from temp file
+    const masterMetadataId = readFileSync(
+      join(__dirname, "..", "tempMasterMetadataId.txt"),
+      { encoding: "utf-8" }
+    );
+
+    // Get the last created Profile ID from temp file
+    const profileId = readFileSync(join(__dirname, "..", "tempProfileId.txt"), {
+      encoding: "utf-8",
+    });
+
+    // Update Master Metadata Title
+    const metadataUpdateRes = await masterModule.updateMetadataTitle(
+      profileId,
+      masterId,
+      masterMetadataId,
+      "This is a new title",
+      getSigner(RECRD_PRIVATE_KEY)
+    );
+
+    console.log(
+      "Master Metadata Title updated successfully:",
+      metadataUpdateRes
+    );
+
+    // Sync the changes of the Metadata to the Master
+    const masterTitleSyncRes = await masterModule.syncMasterTitle(
+      profileId,
+      masterId,
+      masterMetadataId,
+      getSigner(RECRD_PRIVATE_KEY)
+    );
+
+    console.log(
+      "Master Metadata Title synced successfully:",
+      masterTitleSyncRes
+    );
+  } catch (error) {
+    console.error("Failed to update & sync Master Metadata:", error);
+  }
+})();

--- a/scripts/src/tests/profile/testProfileNew.ts
+++ b/scripts/src/tests/profile/testProfileNew.ts
@@ -24,7 +24,16 @@ import { RECRD_PRIVATE_KEY, USER_PRIVATE_KEY } from "../../config";
     );
 
     // Write the profile ID to a temp file for use in other scripts
-    writeFileSync(join(__dirname, "..", "tempProfileId.txt"), result.objectId);
+    writeFileSync(
+      join(__dirname, "..", "tempProfileId.txt"),
+      result.profile.objectId
+    );
+
+    // Write the identity ID to a temp file for use in other scripts
+    writeFileSync(
+      join(__dirname, "..", "tempIdentityId.txt"),
+      result.identity.objectId
+    );
 
     console.log("Profile created successfully:", result);
   } catch (error) {

--- a/scripts/src/tests/profile/testProfileReceive.ts
+++ b/scripts/src/tests/profile/testProfileReceive.ts
@@ -10,14 +10,22 @@ import { join } from "path";
 (async () => {
   try {
     const profileModule = new ProfileModule();
-    
+
     // Get last created Profile ID from temp file
-    const profileId = readFileSync(join(__dirname, '..', 'tempProfileId.txt'), { encoding: 'utf-8' });
+    const profileId = readFileSync(join(__dirname, "..", "tempProfileId.txt"), {
+      encoding: "utf-8",
+    });
 
     // Get last minted Master ID from temp file
-    const masterId = readFileSync(join(__dirname, '..', 'tempMasterId.txt'), { encoding: 'utf-8' });
+    const masterId = readFileSync(join(__dirname, "..", "tempMasterId.txt"), {
+      encoding: "utf-8",
+    });
 
-    const res = await profileModule.receiveMaster(profileId, masterId, getSigner(USER_PRIVATE_KEY));
+    const res = await profileModule.receiveMaster(
+      profileId,
+      masterId,
+      getSigner(RECRD_PRIVATE_KEY)
+    );
 
     console.log("Receive Master response:", res);
   } catch (error) {

--- a/scripts/src/tests/receipt/testReceiptMint.ts
+++ b/scripts/src/tests/receipt/testReceiptMint.ts
@@ -37,13 +37,13 @@ import { getSigner, getSuiAddress } from "../../utils";
     // Write the buyer profile ID to a temp file
     writeFileSync(
       join(__dirname, "..", "tempBuyerProfileId.txt"),
-      buyerProfileRes.objectId
+      buyerProfileRes.profile.objectId
     );
 
     // Create a new Receipt
     const res = await receiptModule.newReceipt(
       masterId,
-      buyerProfileRes.objectId,
+      buyerProfileRes.profile.objectId,
       sellerProfileId,
       getSigner(RECRD_PRIVATE_KEY)
     );

--- a/scripts/src/tests/receipt/testReceiptMint.ts
+++ b/scripts/src/tests/receipt/testReceiptMint.ts
@@ -18,6 +18,14 @@ import { getSigner, getSuiAddress } from "../../utils";
       encoding: "utf-8",
     });
 
+    // Get the seller profile ID from temp file
+    const sellerProfileId = readFileSync(
+      join(__dirname, "..", "tempProfileId.txt"),
+      {
+        encoding: "utf-8",
+      }
+    );
+
     // Create a new Profile for the buyer
     const buyerProfileRes = await profileModule.new(
       "buyer12345",
@@ -36,6 +44,7 @@ import { getSigner, getSuiAddress } from "../../utils";
     const res = await receiptModule.newReceipt(
       masterId,
       buyerProfileRes.objectId,
+      sellerProfileId,
       getSigner(RECRD_PRIVATE_KEY)
     );
     console.log("Receipt created successfully:", res);

--- a/scripts/src/updateDisplay.ts
+++ b/scripts/src/updateDisplay.ts
@@ -1,0 +1,271 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TransactionBlock } from "@mysten/sui.js/transactions";
+import { executeTransaction, getDisplayObjects, getSigner } from "./utils";
+import { SUI_FRAMEWORK_ADDRESS } from "@mysten/sui.js/utils";
+import {
+  MASTER_SOUND_TYPE,
+  MASTER_VIDEO_TYPE,
+  RECRD_PRIVATE_KEY,
+  METADATA_SOUND_TYPE,
+  METADATA_VIDEO_TYPE,
+} from "./config";
+
+const addField = async (
+  txb: TransactionBlock,
+  displayObj: string,
+  type: string,
+  fname: string,
+  fvalue: string
+) => {
+  txb.moveCall({
+    target: `${SUI_FRAMEWORK_ADDRESS}::display::add`,
+    arguments: [txb.object(displayObj), txb.pure(fname), txb.pure(fvalue)],
+    typeArguments: [type],
+  });
+};
+
+const removeField = async (
+  txb: TransactionBlock,
+  displayObj: string,
+  type: string,
+  fname: string
+) => {
+  txb.moveCall({
+    target: `${SUI_FRAMEWORK_ADDRESS}::display::remove`,
+    arguments: [txb.object(displayObj), txb.pure(fname)],
+    typeArguments: [type],
+  });
+};
+
+const editField = async (
+  txb: TransactionBlock,
+  displayObj: string,
+  type: string,
+  fname: string,
+  fvalue: string
+) => {
+  txb.moveCall({
+    target: `${SUI_FRAMEWORK_ADDRESS}::display::edit`,
+    arguments: [txb.object(displayObj), txb.pure(fname), txb.pure(fvalue)],
+    typeArguments: [type],
+  });
+};
+
+const bumpVersion = async (
+  txb: TransactionBlock,
+  displayObj: string,
+  type: string
+) => {
+  txb.moveCall({
+    target: `${SUI_FRAMEWORK_ADDRESS}::display::update_version`,
+    arguments: [txb.object(displayObj)],
+    typeArguments: [type],
+  });
+};
+
+const updateDisplay = async () => {
+  const displayObjs = await getDisplayObjects();
+  console.log("Display objects:", displayObjs);
+  const signer = getSigner(RECRD_PRIVATE_KEY);
+  const txb = new TransactionBlock();
+
+  // ------- Updating Master Sound Display -------
+  // Removing capital case Name to replace with lower case name
+  removeField(txb, displayObjs.masterSoundDisplay!, MASTER_SOUND_TYPE, "Name");
+  addField(
+    txb,
+    displayObjs.masterSoundDisplay!,
+    MASTER_SOUND_TYPE,
+    "name",
+    "{title}"
+  );
+
+  // Removing Image URL field to replace with image_url
+  removeField(
+    txb,
+    displayObjs.masterSoundDisplay!,
+    MASTER_SOUND_TYPE,
+    "Image URL"
+  );
+  addField(
+    txb,
+    displayObjs.masterSoundDisplay!,
+    MASTER_SOUND_TYPE,
+    "image_url",
+    "{image_url}"
+  );
+
+  // Add project_url and creator fields
+  addField(
+    txb,
+    displayObjs.masterSoundDisplay!,
+    MASTER_SOUND_TYPE,
+    "project_url",
+    "https://www.recrd.com/"
+  );
+  addField(
+    txb,
+    displayObjs.masterSoundDisplay!,
+    MASTER_SOUND_TYPE,
+    "creator",
+    "RECRD"
+  );
+
+  // ------- Updating Master Video Display -------
+  // Removing capital case Name to replace with lower case name
+  removeField(txb, displayObjs.masterVideoDisplay!, MASTER_VIDEO_TYPE, "Name");
+  addField(
+    txb,
+    displayObjs.masterVideoDisplay!,
+    MASTER_VIDEO_TYPE,
+    "name",
+    "{title}"
+  );
+
+  // Removing Image URL field to replace with image_url
+  removeField(
+    txb,
+    displayObjs.masterVideoDisplay!,
+    MASTER_VIDEO_TYPE,
+    "Image URL"
+  );
+  addField(
+    txb,
+    displayObjs.masterVideoDisplay!,
+    MASTER_VIDEO_TYPE,
+    "image_url",
+    "{image_url}"
+  );
+
+  // Add project_url and creator fields
+  addField(
+    txb,
+    displayObjs.masterVideoDisplay!,
+    MASTER_VIDEO_TYPE,
+    "project_url",
+    "https://www.recrd.com/"
+  );
+  addField(
+    txb,
+    displayObjs.masterVideoDisplay!,
+    MASTER_VIDEO_TYPE,
+    "creator",
+    "RECRD"
+  );
+
+  // ------- Updating Metadata Video Display -------
+  // Removing Title to replace it with name
+  removeField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "Title"
+  );
+  addField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "name",
+    "{title}"
+  );
+
+  // Removing Image URL field to replace with image_url
+  removeField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "Image URL"
+  );
+  addField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "image_url",
+    "{image_url}"
+  );
+
+  // Add project_url and creator fields
+  addField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "project_url",
+    "https://www.recrd.com/"
+  );
+  addField(
+    txb,
+    displayObjs.metadataVideoDisplay!,
+    METADATA_VIDEO_TYPE,
+    "creator",
+    "RECRD"
+  );
+
+  // ------- Updating Metadata Sound Display -------
+  removeField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "Title"
+  );
+  addField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "name",
+    "{title}"
+  );
+
+  // Removing Image URL field to replace with image_url
+  removeField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "Image URL"
+  );
+  addField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "image_url",
+    "{image_url}"
+  );
+
+  // Add project_url and creator fields
+  addField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "project_url",
+    "https://www.recrd.com/"
+  );
+  addField(
+    txb,
+    displayObjs.metadataSoundDisplay!,
+    METADATA_SOUND_TYPE,
+    "creator",
+    "RECRD"
+  );
+
+  // ------- Bumping the version of all display objects so explorers can update -------
+  bumpVersion(txb, displayObjs.masterSoundDisplay!, MASTER_SOUND_TYPE);
+  bumpVersion(txb, displayObjs.masterVideoDisplay!, MASTER_VIDEO_TYPE);
+  bumpVersion(txb, displayObjs.metadataSoundDisplay!, METADATA_SOUND_TYPE);
+  bumpVersion(txb, displayObjs.metadataVideoDisplay!, METADATA_VIDEO_TYPE);
+
+  // ------- Submitting transaction -------
+  try {
+    const res = await executeTransaction({ txb, signer });
+    if (res.effects?.status.status === "success") {
+      console.log("Display updated successfully!");
+    } else {
+      console.log("Display update failed!");
+      console.error(res.errors);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+updateDisplay();

--- a/scripts/src/utils/index.ts
+++ b/scripts/src/utils/index.ts
@@ -1,19 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { suiClient } from "../config";
+import {
+  suiClient,
+  DIGEST,
+  MASTER_VIDEO_TYPE,
+  MASTER_SOUND_TYPE,
+  METADATA_VIDEO_TYPE,
+  METADATA_SOUND_TYPE,
+} from "../config";
 import { TransactionBlock } from "@mysten/sui.js/transactions";
 import { Signer } from "@mysten/sui.js/dist/cjs/cryptography";
 import { Ed25519Keypair } from "@mysten/sui.js/keypairs/ed25519";
-import { fromB64 } from "@mysten/sui.js/utils";
+import { SUI_FRAMEWORK_ADDRESS, fromB64 } from "@mysten/sui.js/utils";
+import { SuiObjectChangeCreated } from "@mysten/sui.js/client";
 
 interface ExecuteTransactionParams {
-  txb: TransactionBlock; 
+  txb: TransactionBlock;
   signer: Signer;
 }
 
 /// Helper function to sign and execute a transaction with a signer
-export const executeTransaction = async ({ txb, signer }: ExecuteTransactionParams) => {
+export const executeTransaction = async ({
+  txb,
+  signer,
+}: ExecuteTransactionParams) => {
   return suiClient.signAndExecuteTransactionBlock({
     transactionBlock: txb,
     signer,
@@ -35,23 +46,64 @@ export const getSigner = (secretKey: string) => {
   return keypair;
 };
 
+/// Helper function to retrieve Display objects from publish txn Digest
+export const getDisplayObjects = async () => {
+  const txnRes = await suiClient.getTransactionBlock({
+    digest: DIGEST,
+    options: { showObjectChanges: true },
+  });
+  const objectChanges = txnRes.objectChanges?.filter(
+    (obj) => obj.type === "created"
+  ) as SuiObjectChangeCreated[];
+  const displayObjects = {
+    masterVideoDisplay: objectChanges.find(
+      (obj) =>
+        obj.objectType ===
+        `${SUI_FRAMEWORK_ADDRESS}::display::Display<${MASTER_VIDEO_TYPE}>`
+    )?.objectId,
+    masterSoundDisplay: objectChanges?.find(
+      (obj) =>
+        obj.objectType ===
+        `${SUI_FRAMEWORK_ADDRESS}::display::Display<${MASTER_SOUND_TYPE}>`
+    )?.objectId,
+    metadataVideoDisplay: objectChanges?.find(
+      (obj) =>
+        obj.objectType ===
+        `${SUI_FRAMEWORK_ADDRESS}::display::Display<${METADATA_VIDEO_TYPE}>`
+    )?.objectId,
+    metadataSoundDisplay: objectChanges?.find(
+      (obj) =>
+        obj.objectType ===
+        `${SUI_FRAMEWORK_ADDRESS}::display::Display<${METADATA_SOUND_TYPE}>`
+    )?.objectId,
+  };
+  if (
+    !displayObjects.masterVideoDisplay ||
+    !displayObjects.masterSoundDisplay ||
+    !displayObjects.metadataVideoDisplay ||
+    !displayObjects.metadataSoundDisplay
+  ) {
+    throw new Error("Display object(s) not found");
+  }
+  return displayObjects;
+};
+
 /// Helper function to get the Sui address from a private key
 export const getSuiAddress = (secretKey: string) => {
   const keypair = getSigner(secretKey);
   return keypair.getPublicKey().toSuiAddress();
 };
 
+/// Get the <T> type of a Master object
+export const getMasterT = (type: string): string | null => {
+  const regex = /Master<(.+)>/;
+  const match = type.match(regex);
+  return match ? match[1] : null;
+};
 
-  /// Get the <T> type of a Master object
-  export const getMasterT = ( type: string ): string | null => {
-    const regex = /Master<(.+)>/;
-    const match = type.match(regex);
-    return match ? match[1] : null;
-  }
-
-  /// Get the <T> type of a MasterMetadata object
-  export const getMasterMetadataT = ( type: string ): string | null => {
-    const regex = /Metadata<(.+)>/;
-    const match = type.match(regex);
-    return match ? match[1] : null;
-  }
+/// Get the <T> type of a MasterMetadata object
+export const getMasterMetadataT = (type: string): string | null => {
+  const regex = /Metadata<(.+)>/;
+  const match = type.match(regex);
+  return match ? match[1] : null;
+};


### PR DESCRIPTION
**Below are the findings & suggestions as reported by the auditors and what has been addressed in the PR (bulleted comments are ours 😛 ):**

## Findings

1. ✅ **[UPDATED]:** it is possible for the owner of the Master<T> object to update it’s status after the Receipt has been minted, and before the buy function is called. this way, it will be impossible for the buyer to complete the transaction due to the sale_status == ON_SALE assertion.
    - Adjusted the flow when minting a Receipt. Record now needs to borrow the Master<T> from the user's Profile and pass it the `receipt::new` function where we internally set the `sale_status` to `CLAIMED`. As long as the status is claimed then the user can not list or unlist and the only time the sale_status changes to `RETAINED` is through the `profile::buy` function.

1. ✅ **[UPDATED]:** the setter functions for Metadata<T> does not validate who is performing an update, so anyone can update these values.
    - We require Master as a witness to be passed in the update functions which essentially is only permitted to someone who has borrow access in the authorization table.

## Suggestions

1. ✅ **[UPDATED]:** _the master::sync\_* functions do not check if the correct Metadata<T> object is passed. we suggest adding a check to ensure that `master.id` is the same as `metadata.master_id`._
    - Added a new expected failure test for this as well as a new error code `EInvalidMetadataForMaster`.

1. ✅ **[UPDATED]:** we suggest adding a check in core::bump_registry_version to ensure that the new VERSION is greater than the current one.

1. ❌  **[TBD]:**  we believe that all user-callable functions that change the state of the protocol should use the is_valid_version function.
    - The reason we introduced version control was purely to provide a guarantee to users once (and if) the contract is upgraded to support Kiosks. In which case Recrd shouldn't be able to issue Receipts anymore.

1. ✅ **[UPDATED]:** _update comments for getter functions (profile::watch_time, profile::videos_watched, etc.)_
    - Updated to read "Returns" instead of "Updates".

1. ✅ **[UPDATED]:** _we noticed an inconsistency regarding the range of access levels in the profile module. we suggest updating the comments and assertions to apply the same range._
    - Removed relevant test & assertions since no value is invalid in the u8 range.
    - Removed corresponding error code `EAccessLevelOutOfRange` and re-arranged error code numbering.

1. ✅ **[UPDATED]:** we suggest adding a function that would allow the admin to unsuspend the Master<T> object.

1. ✅ **[UPDATED]:** we believe that profile::admin_receive should not give the AdminCap holder the ability to receive any T object. we suggest splitting the function into admin_receive_master and admin_receive_receipt instead.

1. ❌  **[TBD]:**  we suggest adding a check in set_revenue_total to ensure that revenue_available + revenue_paid + revenue_pending == revenue_total.
    - @StefPler Do you think it's worth the complexity to add this check for these static fields? 
      - Decided not to add this since these fields are not handled on chain and their logic is also off chain

1. ✅ **[UPDATED]:** profile::borrow_master can use profile::access_rights. also, it is unnecessary to check if self.authorizations.cointains(ctx.sender()) before calling the profile::access_rights function, as it performs the same assertion.