### PR TITLE
Fix display fields in move tests for Master and Metadata

### DIFF
--- a/move/tests/master_test.move
+++ b/move/tests/master_test.move
@@ -56,10 +56,12 @@ module recrd::master_test {
         ts::next_tx(&mut scenario, ADMIN);
         {
             let master_keys = vector[
-                utf8(b"Name"),
-                utf8(b"Image URL"),
-                utf8(b"Media URL"),
-                utf8(b"Metadata Ref"),
+                utf8(b"name"),
+                utf8(b"image_url"),
+                utf8(b"medial_url"),
+                utf8(b"metadata_ref"),
+                utf8(b"project_url"),
+                utf8(b"creator"),
             ];
 
             let master_values = vector[
@@ -67,6 +69,8 @@ module recrd::master_test {
                 utf8(b"{image_url}"),
                 utf8(b"{media_url}"),
                 utf8(b"{metadata_ref}"),
+                utf8(b"https://www.recrd.com/"),
+                utf8(b"RECRD"),
             ];
 
             let master_display = ts::take_from_sender<Display<Master<Video>>>(&scenario);
@@ -82,15 +86,17 @@ module recrd::master_test {
         ts::next_tx(&mut scenario, ADMIN);
         {
             let metadata_keys = vector[
-                utf8(b"Title"),
-                utf8(b"Description"),
-                utf8(b"Image URL"),
-                utf8(b"Media URL"),
-                utf8(b"Hashtags"),
-                utf8(b"Creator"),
-                utf8(b"Parent"),
-                utf8(b"Origin"),
-                utf8(b"Expressions"),
+                utf8(b"name"),
+                utf8(b"description"),
+                utf8(b"image_url"),
+                utf8(b"media_url"),
+                utf8(b"hashtags"),
+                utf8(b"creator_profile"),
+                utf8(b"parent"),
+                utf8(b"origin"),
+                utf8(b"expressions"),
+                utf8(b"project_url"),
+                utf8(b"creator"),
             ];
 
             let metadata_values = vector[
@@ -103,6 +109,8 @@ module recrd::master_test {
                 utf8(b"{master_metadata_parent}"),
                 utf8(b"{master_metadata_origin}"),
                 utf8(b"{expressions}"),
+                utf8(b"https://www.recrd.com/"),
+                utf8(b"RECRD"),
             ];
 
             let metadata_display = ts::take_from_sender<Display<Metadata<Video>>>(&scenario);

--- a/move/tests/profile_test.move
+++ b/move/tests/profile_test.move
@@ -7,9 +7,7 @@ module recrd::profile_test {
 
     use recrd::core::{Self};
     use recrd::profile::{Self, Profile, ENewValueShouldBeHigher, ENotAuthorized};
-    use recrd::master::{Video};
     use recrd::identity::{Identity};
-    use recrd::master_test;
 
     // === Constants ===
     const USERNAME: vector<u8> = b"username";


### PR DESCRIPTION
Updated the display fields for Master and Metadata in move tests