### PR TITLE
[SUI] CHORE: add YouTrack timesheet caller workflow (BCK-3118)

### DIFF
--- a/.github/workflows/youtrack-timesheet.yml
+++ b/.github/workflows/youtrack-timesheet.yml
@@ -1,0 +1,9 @@
+name: YouTrack timesheet
+on:
+  push:
+    branches-ignore: [main, master, staging, develop]
+jobs:
+  log:
+    uses: RecrdGroup/recrd-workflows/.github/workflows/youtrack-timesheet.yml@main
+    secrets:
+      YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}


### PR DESCRIPTION
Adds the caller for the reusable YouTrack timesheet workflow in recrd-workflows — logs a 15m YouTrack work item per pushed commit (Tempo parity). Verified end-to-end on trym-science.

⚠️ Merge **after** RecrdGroup/recrd-workflows#1 (the reusable workflow itself).

Jira: https://recrd.atlassian.net/browse/BCK-3118

🤖 Generated with [Claude Code](https://claude.com/claude-code)