### PR TITLE
[SUI] CHORE: log PR reviews to YouTrack timesheets (BCK-3120)

### DIFF
--- a/.github/workflows/youtrack-timesheet.yml
+++ b/.github/workflows/youtrack-timesheet.yml
@@ -2,8 +2,21 @@ name: YouTrack timesheet
 on:
   push:
     branches-ignore: [main, master, staging, develop]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
 jobs:
-  log:
+  commits:
+    if: github.event_name == 'push'
     uses: RecrdGroup/recrd-workflows/.github/workflows/youtrack-timesheet.yml@main
+    secrets:
+      YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
+  review:
+    # issue_comment fires on plain issues too — only act when it's a PR.
+    if: github.event_name != 'push' && (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+    uses: RecrdGroup/recrd-workflows/.github/workflows/youtrack-timesheet-review.yml@main
     secrets:
       YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}


### PR DESCRIPTION
Adds PR-review time logging to the YouTrack timesheet caller: `pull_request_review`, `pull_request_review_comment` and `issue_comment` (PRs only) triggers plus an event-routed `review` job calling `recrd-workflows/.github/workflows/youtrack-timesheet-review.yml@main`. The existing per-commit `commits` job is unchanged.

Depends on recrd-workflows#3 (the review reusable workflow) reaching `main`. Review-event workflows run from the default branch, so review logging activates for this repo once this caller reaches `main` via the normal staging→main promotion.

YouTrack: BCK-3120

🤖 Generated with [Claude Code](https://claude.com/claude-code)